### PR TITLE
feat: Family Leaderboard — weekly competition (#113)

### DIFF
--- a/lib/data/repositories/firebase_leaderboard_repository.dart
+++ b/lib/data/repositories/firebase_leaderboard_repository.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../domain/repositories/leaderboard_repository.dart';
 import '../../domain/entities/user.dart';
+import '../../domain/entities/leaderboard_entry.dart';
 import '../../domain/value_objects/family_id.dart';
 import '../../domain/value_objects/user_id.dart';
 import '../../domain/value_objects/email.dart';
@@ -31,6 +32,136 @@ class FirebaseLeaderboardRepository implements LeaderboardRepository {
     } catch (e) {
       throw ServerException('Failed to get leaderboard: $e', code: 'LEADERBOARD_FETCH_ERROR');
     }
+  }
+
+  @override
+  Future<List<LeaderboardEntry>> getWeeklyLeaderboard(FamilyId familyId) async {
+    try {
+      // Get all users in the family with their stats
+      final snapshot = await _firestore
+          .collection('users')
+          .where('familyId', isEqualTo: familyId.value)
+          .get();
+
+      final entries = snapshot.docs.map((doc) {
+        final data = doc.data();
+        final stats = data['stats'] as Map<String, dynamic>? ?? {};
+        
+        return LeaderboardEntry(
+          userId: UserId(doc.id),
+          userName: data['name'] as String? ?? '',
+          userPhotoUrl: data['photoUrl'] as String?,
+          points: Points(data['points'] as int? ?? 0),
+          completedTasks: data['completedTasks'] as int? ?? 0,
+          rank: 0, // Will be assigned after sorting
+          weeklyStars: stats['starsEarnedThisWeek'] as int? ?? 0,
+          allTimeStars: stats['totalStarsAllTime'] as int? ?? (data['points'] as int? ?? 0),
+          questsCompleted: stats['totalQuestsCompleted'] as int? ?? 0,
+          longestStreak: stats['longestStreak'] as int? ?? 0,
+          currentStreak: stats['currentStreak'] as int? ?? 0,
+          previousRank: stats['lastWeekRank'] as int?,
+          hasChampionBadge: stats['hasChampionBadge'] as bool? ?? false,
+        );
+      }).toList();
+
+      // Sort by weekly stars with tiebreaker rules:
+      // 1. Most weekly stars
+      // 2. Most quests completed this week
+      // 3. Longest current streak
+      // 4. Alphabetical by name
+      entries.sort((a, b) {
+        // Primary: weekly stars descending
+        final starComparison = b.weeklyStars.compareTo(a.weeklyStars);
+        if (starComparison != 0) return starComparison;
+        
+        // Tiebreaker 1: quests completed descending
+        final questComparison = b.questsCompleted.compareTo(a.questsCompleted);
+        if (questComparison != 0) return questComparison;
+        
+        // Tiebreaker 2: longest streak descending
+        final streakComparison = b.longestStreak.compareTo(a.longestStreak);
+        if (streakComparison != 0) return streakComparison;
+        
+        // Tiebreaker 3: alphabetical ascending
+        return a.userName.compareTo(b.userName);
+      });
+
+      // Assign ranks
+      final rankedEntries = <LeaderboardEntry>[];
+      for (var i = 0; i < entries.length; i++) {
+        rankedEntries.add(entries[i].copyWith(rank: i + 1));
+      }
+
+      return rankedEntries;
+    } catch (e) {
+      throw ServerException('Failed to get weekly leaderboard: $e', code: 'LEADERBOARD_FETCH_ERROR');
+    }
+  }
+
+  @override
+  Future<List<LeaderboardEntry>> getAllTimeLeaderboard(FamilyId familyId) async {
+    try {
+      // Get all users in the family with their all-time stats
+      final snapshot = await _firestore
+          .collection('users')
+          .where('familyId', isEqualTo: familyId.value)
+          .get();
+
+      final entries = snapshot.docs.map((doc) {
+        final data = doc.data();
+        final stats = data['stats'] as Map<String, dynamic>? ?? {};
+        
+        return LeaderboardEntry(
+          userId: UserId(doc.id),
+          userName: data['name'] as String? ?? '',
+          userPhotoUrl: data['photoUrl'] as String?,
+          points: Points(data['points'] as int? ?? 0),
+          completedTasks: data['completedTasks'] as int? ?? 0,
+          rank: 0, // Will be assigned after sorting
+          weeklyStars: stats['starsEarnedThisWeek'] as int? ?? 0,
+          allTimeStars: stats['totalStarsAllTime'] as int? ?? (data['points'] as int? ?? 0),
+          questsCompleted: stats['totalQuestsCompleted'] as int? ?? 0,
+          longestStreak: stats['longestStreak'] as int? ?? 0,
+          currentStreak: stats['currentStreak'] as int? ?? 0,
+          hasChampionBadge: stats['hasChampionBadge'] as bool? ?? false,
+        );
+      }).toList();
+
+      // Sort by all-time stars descending
+      entries.sort((a, b) => b.allTimeStars.compareTo(a.allTimeStars));
+
+      // Assign ranks
+      final rankedEntries = <LeaderboardEntry>[];
+      for (var i = 0; i < entries.length; i++) {
+        rankedEntries.add(entries[i].copyWith(rank: i + 1));
+      }
+
+      return rankedEntries;
+    } catch (e) {
+      throw ServerException('Failed to get all-time leaderboard: $e', code: 'LEADERBOARD_FETCH_ERROR');
+    }
+  }
+
+  @override
+  DateTime getCurrentWeekStart() {
+    final now = DateTime.now();
+    final currentWeekday = now.weekday; // Monday = 1, Sunday = 7
+    
+    // Calculate days to subtract to get to Monday
+    final daysToMonday = currentWeekday - 1;
+    
+    // Get Monday at 00:00:00
+    final monday = DateTime(now.year, now.month, now.day)
+        .subtract(Duration(days: daysToMonday));
+    
+    return monday;
+  }
+
+  @override
+  DateTime getCurrentWeekEnd() {
+    final weekStart = getCurrentWeekStart();
+    // Sunday at 23:59:59
+    return weekStart.add(const Duration(days: 7)).subtract(const Duration(seconds: 1));
   }
 
   /// Maps Firestore document data to domain User entity

--- a/lib/data/repositories/mock_leaderboard_repository.dart
+++ b/lib/data/repositories/mock_leaderboard_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import '../../domain/repositories/leaderboard_repository.dart';
 import '../../domain/entities/user.dart';
+import '../../domain/entities/leaderboard_entry.dart';
 import '../../domain/value_objects/family_id.dart';
 import '../../domain/value_objects/user_id.dart';
 import '../../domain/value_objects/email.dart';
@@ -10,72 +11,124 @@ import '../../core/error/exceptions.dart';
 /// Mock implementation of LeaderboardRepository for testing
 class MockLeaderboardRepository implements LeaderboardRepository {
   final List<User> _users = [];
+  final Map<String, Map<String, dynamic>> _userStats = {};
 
   MockLeaderboardRepository() {
     _initializeMockData();
   }
 
   void _initializeMockData() {
-    // Create some mock users for leaderboard
+    // Create some mock users for leaderboard with varied stats
     final mockUsers = [
       User(
         id: UserId('user_1'),
-        name: 'John Doe',
-        email: Email('john@example.com'),
+        name: 'Amira',
+        email: Email('amira@example.com'),
         photoUrl: null,
         familyId: FamilyId('family_1'),
-        role: UserRole.parent,
-        points: Points(450),
-        joinedAt: DateTime.now().subtract(const Duration(days: 30)),
+        role: UserRole.child,
+        points: Points(2847),
+        joinedAt: DateTime.now().subtract(const Duration(days: 180)),
         updatedAt: DateTime.now(),
       ),
       User(
         id: UserId('user_2'),
-        name: 'Jane Smith',
-        email: Email('jane@example.com'),
+        name: 'Omar',
+        email: Email('omar@example.com'),
         photoUrl: null,
         familyId: FamilyId('family_1'),
         role: UserRole.child,
-        points: Points(320),
-        joinedAt: DateTime.now().subtract(const Duration(days: 25)),
+        points: Points(2341),
+        joinedAt: DateTime.now().subtract(const Duration(days: 175)),
         updatedAt: DateTime.now(),
       ),
       User(
         id: UserId('user_3'),
-        name: 'Bob Johnson',
-        email: Email('bob@example.com'),
+        name: 'Sara',
+        email: Email('sara@example.com'),
         photoUrl: null,
         familyId: FamilyId('family_1'),
         role: UserRole.child,
-        points: Points(280),
-        joinedAt: DateTime.now().subtract(const Duration(days: 20)),
+        points: Points(1987),
+        joinedAt: DateTime.now().subtract(const Duration(days: 160)),
         updatedAt: DateTime.now(),
       ),
       User(
         id: UserId('user_4'),
-        name: 'Alice Wilson',
-        email: Email('alice@example.com'),
+        name: 'Ahmed',
+        email: Email('ahmed@example.com'),
         photoUrl: null,
         familyId: FamilyId('family_1'),
         role: UserRole.child,
-        points: Points(150),
-        joinedAt: DateTime.now().subtract(const Duration(days: 15)),
+        points: Points(1654),
+        joinedAt: DateTime.now().subtract(const Duration(days: 140)),
         updatedAt: DateTime.now(),
       ),
       User(
         id: UserId('user_5'),
-        name: 'Charlie Brown',
-        email: Email('charlie@example.com'),
+        name: 'Layla',
+        email: Email('layla@example.com'),
         photoUrl: null,
         familyId: FamilyId('family_1'),
         role: UserRole.child,
-        points: Points(90),
-        joinedAt: DateTime.now().subtract(const Duration(days: 10)),
+        points: Points(1203),
+        joinedAt: DateTime.now().subtract(const Duration(days: 120)),
         updatedAt: DateTime.now(),
       ),
     ];
 
     _users.addAll(mockUsers);
+    
+    // Initialize weekly stats
+    _userStats['user_1'] = {
+      'starsEarnedThisWeek': 127,
+      'totalStarsAllTime': 2847,
+      'totalQuestsCompleted': 189,
+      'longestStreak': 34,
+      'currentStreak': 12,
+      'lastWeekRank': 1,
+      'hasChampionBadge': true,
+    };
+    
+    _userStats['user_2'] = {
+      'starsEarnedThisWeek': 98,
+      'totalStarsAllTime': 2341,
+      'totalQuestsCompleted': 156,
+      'longestStreak': 28,
+      'currentStreak': 8,
+      'lastWeekRank': 3,
+      'hasChampionBadge': false,
+    };
+    
+    _userStats['user_3'] = {
+      'starsEarnedThisWeek': 85,
+      'totalStarsAllTime': 1987,
+      'totalQuestsCompleted': 132,
+      'longestStreak': 21,
+      'currentStreak': 5,
+      'lastWeekRank': 2,
+      'hasChampionBadge': false,
+    };
+    
+    _userStats['user_4'] = {
+      'starsEarnedThisWeek': 62,
+      'totalStarsAllTime': 1654,
+      'totalQuestsCompleted': 110,
+      'longestStreak': 18,
+      'currentStreak': 3,
+      'lastWeekRank': 4,
+      'hasChampionBadge': false,
+    };
+    
+    _userStats['user_5'] = {
+      'starsEarnedThisWeek': 45,
+      'totalStarsAllTime': 1203,
+      'totalQuestsCompleted': 85,
+      'longestStreak': 15,
+      'currentStreak': 1,
+      'lastWeekRank': 5,
+      'hasChampionBadge': false,
+    };
   }
 
   @override
@@ -95,6 +148,126 @@ class MockLeaderboardRepository implements LeaderboardRepository {
     }
   }
 
+  @override
+  Future<List<LeaderboardEntry>> getWeeklyLeaderboard(FamilyId familyId) async {
+    try {
+      await Future.delayed(const Duration(milliseconds: 150)); // Simulate network delay
+      
+      // Get users for the specific family
+      final familyUsers = _users.where((user) => user.familyId == familyId).toList();
+      
+      // Build leaderboard entries
+      final entries = familyUsers.map((user) {
+        final stats = _userStats[user.id.value] ?? {};
+        
+        return LeaderboardEntry(
+          userId: user.id,
+          userName: user.name,
+          userPhotoUrl: user.photoUrl,
+          points: user.points,
+          completedTasks: stats['totalQuestsCompleted'] as int? ?? 0,
+          rank: 0, // Will be assigned after sorting
+          weeklyStars: stats['starsEarnedThisWeek'] as int? ?? 0,
+          allTimeStars: stats['totalStarsAllTime'] as int? ?? user.points.toInt(),
+          questsCompleted: stats['totalQuestsCompleted'] as int? ?? 0,
+          longestStreak: stats['longestStreak'] as int? ?? 0,
+          currentStreak: stats['currentStreak'] as int? ?? 0,
+          previousRank: stats['lastWeekRank'] as int?,
+          hasChampionBadge: stats['hasChampionBadge'] as bool? ?? false,
+        );
+      }).toList();
+
+      // Sort by weekly stars with tiebreaker rules
+      entries.sort((a, b) {
+        final starComparison = b.weeklyStars.compareTo(a.weeklyStars);
+        if (starComparison != 0) return starComparison;
+        
+        final questComparison = b.questsCompleted.compareTo(a.questsCompleted);
+        if (questComparison != 0) return questComparison;
+        
+        final streakComparison = b.longestStreak.compareTo(a.longestStreak);
+        if (streakComparison != 0) return streakComparison;
+        
+        return a.userName.compareTo(b.userName);
+      });
+
+      // Assign ranks
+      final rankedEntries = <LeaderboardEntry>[];
+      for (var i = 0; i < entries.length; i++) {
+        rankedEntries.add(entries[i].copyWith(rank: i + 1));
+      }
+
+      return rankedEntries;
+    } catch (e) {
+      throw ServerException('Failed to get weekly leaderboard: $e', code: 'LEADERBOARD_FETCH_ERROR');
+    }
+  }
+
+  @override
+  Future<List<LeaderboardEntry>> getAllTimeLeaderboard(FamilyId familyId) async {
+    try {
+      await Future.delayed(const Duration(milliseconds: 150)); // Simulate network delay
+      
+      // Get users for the specific family
+      final familyUsers = _users.where((user) => user.familyId == familyId).toList();
+      
+      // Build leaderboard entries
+      final entries = familyUsers.map((user) {
+        final stats = _userStats[user.id.value] ?? {};
+        
+        return LeaderboardEntry(
+          userId: user.id,
+          userName: user.name,
+          userPhotoUrl: user.photoUrl,
+          points: user.points,
+          completedTasks: stats['totalQuestsCompleted'] as int? ?? 0,
+          rank: 0, // Will be assigned after sorting
+          weeklyStars: stats['starsEarnedThisWeek'] as int? ?? 0,
+          allTimeStars: stats['totalStarsAllTime'] as int? ?? user.points.toInt(),
+          questsCompleted: stats['totalQuestsCompleted'] as int? ?? 0,
+          longestStreak: stats['longestStreak'] as int? ?? 0,
+          currentStreak: stats['currentStreak'] as int? ?? 0,
+          hasChampionBadge: stats['hasChampionBadge'] as bool? ?? false,
+        );
+      }).toList();
+
+      // Sort by all-time stars descending
+      entries.sort((a, b) => b.allTimeStars.compareTo(a.allTimeStars));
+
+      // Assign ranks
+      final rankedEntries = <LeaderboardEntry>[];
+      for (var i = 0; i < entries.length; i++) {
+        rankedEntries.add(entries[i].copyWith(rank: i + 1));
+      }
+
+      return rankedEntries;
+    } catch (e) {
+      throw ServerException('Failed to get all-time leaderboard: $e', code: 'LEADERBOARD_FETCH_ERROR');
+    }
+  }
+
+  @override
+  DateTime getCurrentWeekStart() {
+    final now = DateTime.now();
+    final currentWeekday = now.weekday; // Monday = 1, Sunday = 7
+    
+    // Calculate days to subtract to get to Monday
+    final daysToMonday = currentWeekday - 1;
+    
+    // Get Monday at 00:00:00
+    final monday = DateTime(now.year, now.month, now.day)
+        .subtract(Duration(days: daysToMonday));
+    
+    return monday;
+  }
+
+  @override
+  DateTime getCurrentWeekEnd() {
+    final weekStart = getCurrentWeekStart();
+    // Sunday at 23:59:59
+    return weekStart.add(const Duration(days: 7)).subtract(const Duration(seconds: 1));
+  }
+
   /// Helper method to update user points (for testing)
   void updateUserPoints(UserId userId, Points newPoints) {
     final index = _users.indexWhere((user) => user.id == userId);
@@ -103,6 +276,13 @@ class MockLeaderboardRepository implements LeaderboardRepository {
         points: newPoints,
         updatedAt: DateTime.now(),
       );
+    }
+  }
+  
+  /// Helper method to update weekly stars (for testing)
+  void updateWeeklyStars(String userId, int stars) {
+    if (_userStats.containsKey(userId)) {
+      _userStats[userId]!['starsEarnedThisWeek'] = stars;
     }
   }
 } 

--- a/lib/di/riverpod_container.dart
+++ b/lib/di/riverpod_container.dart
@@ -234,6 +234,18 @@ GetLeaderboardUseCase getLeaderboardUseCase(Ref ref) {
   return GetLeaderboardUseCase(leaderboardRepository);
 }
 
+@riverpod
+GetWeeklyLeaderboardUseCase getWeeklyLeaderboardUseCase(Ref ref) {
+  final leaderboardRepository = ref.watch(leaderboardRepositoryProvider);
+  return GetWeeklyLeaderboardUseCase(leaderboardRepository);
+}
+
+@riverpod
+GetAllTimeLeaderboardUseCase getAllTimeLeaderboardUseCase(Ref ref) {
+  final leaderboardRepository = ref.watch(leaderboardRepositoryProvider);
+  return GetAllTimeLeaderboardUseCase(leaderboardRepository);
+}
+
 // Additional Task Use Cases
 @riverpod
 UpdateTaskUseCase updateTaskUseCase(Ref ref) {

--- a/lib/di/riverpod_container.g.dart
+++ b/lib/di/riverpod_container.g.dart
@@ -517,6 +517,48 @@ final getLeaderboardUseCaseProvider =
 // ignore: unused_element
 typedef GetLeaderboardUseCaseRef =
     AutoDisposeProviderRef<GetLeaderboardUseCase>;
+String _$getWeeklyLeaderboardUseCaseHash() =>
+    r'4a76a9058c4b56cc33ff35446eca244732a53b7d';
+
+/// See also [getWeeklyLeaderboardUseCase].
+@ProviderFor(getWeeklyLeaderboardUseCase)
+final getWeeklyLeaderboardUseCaseProvider =
+    AutoDisposeProvider<GetWeeklyLeaderboardUseCase>.internal(
+      getWeeklyLeaderboardUseCase,
+      name: r'getWeeklyLeaderboardUseCaseProvider',
+      debugGetCreateSourceHash:
+          const bool.fromEnvironment('dart.vm.product')
+              ? null
+              : _$getWeeklyLeaderboardUseCaseHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef GetWeeklyLeaderboardUseCaseRef =
+    AutoDisposeProviderRef<GetWeeklyLeaderboardUseCase>;
+String _$getAllTimeLeaderboardUseCaseHash() =>
+    r'de24f6c64664ebb8be2220145a63f3b27d4a0065';
+
+/// See also [getAllTimeLeaderboardUseCase].
+@ProviderFor(getAllTimeLeaderboardUseCase)
+final getAllTimeLeaderboardUseCaseProvider =
+    AutoDisposeProvider<GetAllTimeLeaderboardUseCase>.internal(
+      getAllTimeLeaderboardUseCase,
+      name: r'getAllTimeLeaderboardUseCaseProvider',
+      debugGetCreateSourceHash:
+          const bool.fromEnvironment('dart.vm.product')
+              ? null
+              : _$getAllTimeLeaderboardUseCaseHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef GetAllTimeLeaderboardUseCaseRef =
+    AutoDisposeProviderRef<GetAllTimeLeaderboardUseCase>;
 String _$updateTaskUseCaseHash() => r'79f901348b8ce9ebe93bc08a5ccb4c1e05fd6b03';
 
 /// See also [updateTaskUseCase].

--- a/lib/domain/entities/leaderboard_entry.dart
+++ b/lib/domain/entities/leaderboard_entry.dart
@@ -8,6 +8,15 @@ class LeaderboardEntry {
   final Points points;
   final int completedTasks;
   final int rank;
+  
+  // Weekly competition fields
+  final int weeklyStars;
+  final int allTimeStars;
+  final int questsCompleted;
+  final int longestStreak;
+  final int currentStreak;
+  final int? previousRank;
+  final bool hasChampionBadge;
 
   const LeaderboardEntry({
     required this.userId,
@@ -16,6 +25,13 @@ class LeaderboardEntry {
     required this.points,
     required this.completedTasks,
     required this.rank,
+    this.weeklyStars = 0,
+    this.allTimeStars = 0,
+    this.questsCompleted = 0,
+    this.longestStreak = 0,
+    this.currentStreak = 0,
+    this.previousRank,
+    this.hasChampionBadge = false,
   });
 
   /// Creates a copy of this entry with optional new values.
@@ -26,6 +42,13 @@ class LeaderboardEntry {
     Points? points,
     int? completedTasks,
     int? rank,
+    int? weeklyStars,
+    int? allTimeStars,
+    int? questsCompleted,
+    int? longestStreak,
+    int? currentStreak,
+    int? previousRank,
+    bool? hasChampionBadge,
   }) {
     return LeaderboardEntry(
       userId: userId ?? this.userId,
@@ -34,7 +57,25 @@ class LeaderboardEntry {
       points: points ?? this.points,
       completedTasks: completedTasks ?? this.completedTasks,
       rank: rank ?? this.rank,
+      weeklyStars: weeklyStars ?? this.weeklyStars,
+      allTimeStars: allTimeStars ?? this.allTimeStars,
+      questsCompleted: questsCompleted ?? this.questsCompleted,
+      longestStreak: longestStreak ?? this.longestStreak,
+      currentStreak: currentStreak ?? this.currentStreak,
+      previousRank: previousRank ?? this.previousRank,
+      hasChampionBadge: hasChampionBadge ?? this.hasChampionBadge,
     );
+  }
+  
+  /// Check if user is on the podium (top 3)
+  bool get isOnPodium => rank >= 1 && rank <= 3;
+  
+  /// Get rank change indicator
+  RankChange get rankChange {
+    if (previousRank == null) return RankChange.none;
+    if (previousRank! > rank) return RankChange.up;
+    if (previousRank! < rank) return RankChange.down;
+    return RankChange.same;
   }
 
   @override
@@ -46,7 +87,14 @@ class LeaderboardEntry {
         other.userPhotoUrl == userPhotoUrl &&
         other.points == points &&
         other.completedTasks == completedTasks &&
-        other.rank == rank;
+        other.rank == rank &&
+        other.weeklyStars == weeklyStars &&
+        other.allTimeStars == allTimeStars &&
+        other.questsCompleted == questsCompleted &&
+        other.longestStreak == longestStreak &&
+        other.currentStreak == currentStreak &&
+        other.previousRank == previousRank &&
+        other.hasChampionBadge == hasChampionBadge;
   }
 
   @override
@@ -56,11 +104,26 @@ class LeaderboardEntry {
         userPhotoUrl.hashCode ^
         points.hashCode ^
         completedTasks.hashCode ^
-        rank.hashCode;
+        rank.hashCode ^
+        weeklyStars.hashCode ^
+        allTimeStars.hashCode ^
+        questsCompleted.hashCode ^
+        longestStreak.hashCode ^
+        currentStreak.hashCode ^
+        previousRank.hashCode ^
+        hasChampionBadge.hashCode;
   }
 
   @override
   String toString() {
-    return 'LeaderboardEntry(userId: $userId, userName: $userName, points: $points, completedTasks: $completedTasks, rank: $rank)';
+    return 'LeaderboardEntry(userId: $userId, userName: $userName, rank: $rank, weeklyStars: $weeklyStars, allTimeStars: $allTimeStars)';
   }
+}
+
+/// Enum for rank change indicators
+enum RankChange {
+  up,
+  down,
+  same,
+  none;
 } 

--- a/lib/domain/repositories/leaderboard_repository.dart
+++ b/lib/domain/repositories/leaderboard_repository.dart
@@ -1,8 +1,22 @@
 import '../entities/user.dart';
+import '../entities/leaderboard_entry.dart';
 import '../value_objects/family_id.dart';
 
 /// Abstract interface for leaderboard data operations
 abstract class LeaderboardRepository {
-  /// Get leaderboard entries for a family
+  /// Get leaderboard entries for a family (all-time)
   Future<List<User>> getLeaderboard(FamilyId familyId);
+  
+  /// Get weekly leaderboard entries for a family
+  /// Returns entries sorted by stars earned this week (Monday-Sunday)
+  Future<List<LeaderboardEntry>> getWeeklyLeaderboard(FamilyId familyId);
+  
+  /// Get all-time statistics leaderboard
+  Future<List<LeaderboardEntry>> getAllTimeLeaderboard(FamilyId familyId);
+  
+  /// Get the current week start date (Monday at 00:00)
+  DateTime getCurrentWeekStart();
+  
+  /// Get the current week end date (Sunday at 23:59)
+  DateTime getCurrentWeekEnd();
 } 

--- a/lib/domain/usecases/leaderboard/get_alltime_leaderboard_usecase.dart
+++ b/lib/domain/usecases/leaderboard/get_alltime_leaderboard_usecase.dart
@@ -1,0 +1,35 @@
+import 'package:dartz/dartz.dart' hide Task;
+import '../../../core/error/failures.dart';
+import '../../../core/error/exceptions.dart';
+import '../../entities/leaderboard_entry.dart';
+import '../../repositories/leaderboard_repository.dart';
+import '../../value_objects/family_id.dart';
+
+/// Use case for getting all-time leaderboard data
+/// 
+/// Shows lifetime statistics: total stars, quests completed, longest streak, weekly wins
+class GetAllTimeLeaderboardUseCase {
+  final LeaderboardRepository _leaderboardRepository;
+
+  GetAllTimeLeaderboardUseCase(this._leaderboardRepository);
+
+  /// Gets all-time leaderboard entries for a family
+  /// 
+  /// [familyId] - ID of the family to get leaderboard for
+  /// 
+  /// Returns [List<LeaderboardEntry>] on success or [Failure] on error
+  Future<Either<Failure, List<LeaderboardEntry>>> call({
+    required FamilyId familyId,
+  }) async {
+    try {
+      final entries = await _leaderboardRepository.getAllTimeLeaderboard(familyId);
+      
+      // Entries are pre-sorted by total stars descending
+      return Right(entries);
+    } on DataException catch (e) {
+      return Left(ServerFailure(e.message, code: e.code));
+    } catch (e) {
+      return Left(ServerFailure('Failed to get all-time leaderboard: $e'));
+    }
+  }
+}

--- a/lib/domain/usecases/leaderboard/get_weekly_leaderboard_usecase.dart
+++ b/lib/domain/usecases/leaderboard/get_weekly_leaderboard_usecase.dart
@@ -1,0 +1,65 @@
+import 'package:dartz/dartz.dart' hide Task;
+import '../../../core/error/failures.dart';
+import '../../../core/error/exceptions.dart';
+import '../../entities/leaderboard_entry.dart';
+import '../../repositories/leaderboard_repository.dart';
+import '../../value_objects/family_id.dart';
+
+/// Use case for getting weekly leaderboard data
+/// 
+/// Queries stars earned this week (Monday-Sunday) and ranks family members.
+/// Applies tiebreaker rules: most quests → longest streak → alphabetical
+class GetWeeklyLeaderboardUseCase {
+  final LeaderboardRepository _leaderboardRepository;
+
+  GetWeeklyLeaderboardUseCase(this._leaderboardRepository);
+
+  /// Gets weekly leaderboard entries for a family
+  /// 
+  /// [familyId] - ID of the family to get leaderboard for
+  /// 
+  /// Returns [List<LeaderboardEntry>] on success or [Failure] on error
+  Future<Either<Failure, List<LeaderboardEntry>>> call({
+    required FamilyId familyId,
+  }) async {
+    try {
+      final entries = await _leaderboardRepository.getWeeklyLeaderboard(familyId);
+      
+      // Entries are pre-sorted by repository with tiebreaker rules applied
+      // Rank is already assigned
+      return Right(entries);
+    } on DataException catch (e) {
+      return Left(ServerFailure(e.message, code: e.code));
+    } catch (e) {
+      return Left(ServerFailure('Failed to get weekly leaderboard: $e'));
+    }
+  }
+
+  /// Gets current week start date (Monday at 00:00)
+  DateTime getWeekStart() {
+    return _leaderboardRepository.getCurrentWeekStart();
+  }
+
+  /// Gets current week end date (Sunday at 23:59)
+  DateTime getWeekEnd() {
+    return _leaderboardRepository.getCurrentWeekEnd();
+  }
+  
+  /// Gets top N users from weekly leaderboard
+  /// 
+  /// [familyId] - ID of the family to get leaderboard for
+  /// [limit] - Number of top users to return (default: 3 for podium)
+  /// 
+  /// Returns [List<LeaderboardEntry>] on success or [Failure] on error
+  Future<Either<Failure, List<LeaderboardEntry>>> getTopUsers({
+    required FamilyId familyId,
+    int limit = 3,
+  }) async {
+    try {
+      final result = await call(familyId: familyId);
+      return result.map((entries) => entries.take(limit).toList());
+    } catch (e) {
+      return Left(ServerFailure('Failed to get top users: $e'));
+    }
+  }
+}

--- a/lib/domain/usecases/usecases.dart
+++ b/lib/domain/usecases/usecases.dart
@@ -59,6 +59,8 @@ export 'gamification/get_rewards_usecase.dart';
 
 // Leaderboard Use Cases
 export 'leaderboard/get_leaderboard_usecase.dart';
+export 'leaderboard/get_weekly_leaderboard_usecase.dart';
+export 'leaderboard/get_alltime_leaderboard_usecase.dart';
 
 // Notification Use Cases
 export 'notification/get_notifications_usecase.dart';

--- a/lib/presentation/providers/riverpod/alltime_leaderboard_notifier.dart
+++ b/lib/presentation/providers/riverpod/alltime_leaderboard_notifier.dart
@@ -1,0 +1,94 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:hoque_family_chores/domain/entities/leaderboard_entry.dart';
+import 'package:hoque_family_chores/domain/value_objects/family_id.dart';
+import 'package:hoque_family_chores/utils/logger.dart';
+import 'package:hoque_family_chores/di/riverpod_container.dart';
+
+part 'alltime_leaderboard_notifier.g.dart';
+
+/// Manages all-time leaderboard data for a family.
+/// 
+/// This notifier fetches and manages all-time leaderboard entries showing
+/// family member lifetime statistics: total stars, quests completed, longest streak.
+@riverpod
+class AllTimeLeaderboardNotifier extends _$AllTimeLeaderboardNotifier {
+  final _logger = AppLogger();
+
+  @override
+  Future<List<LeaderboardEntry>> build(FamilyId familyId) async {
+    _logger.d('AllTimeLeaderboardNotifier: Building for family $familyId');
+    
+    try {
+      final getAllTimeLeaderboardUseCase = ref.watch(getAllTimeLeaderboardUseCaseProvider);
+      final result = await getAllTimeLeaderboardUseCase.call(familyId: familyId);
+      
+      return result.fold(
+        (failure) => throw Exception(failure.message),
+        (entries) {
+          _logger.d('AllTimeLeaderboardNotifier: Loaded ${entries.length} entries for all-time leaderboard');
+          return entries;
+        },
+      );
+    } catch (e) {
+      _logger.e('AllTimeLeaderboardNotifier: Error loading all-time leaderboard', error: e);
+      throw Exception('Failed to load all-time leaderboard: $e');
+    }
+  }
+
+  /// Refreshes the all-time leaderboard data.
+  Future<void> refresh() async {
+    _logger.d('AllTimeLeaderboardNotifier: Refreshing all-time leaderboard');
+    ref.invalidateSelf();
+  }
+
+  /// Gets the current list of leaderboard entries.
+  List<LeaderboardEntry> get entries => state.value ?? [];
+
+  /// Gets the current loading state.
+  bool get isLoading => state.isLoading;
+
+  /// Gets the current error message.
+  String? get errorMessage => state.hasError ? state.error.toString() : null;
+
+  /// Gets entries for a specific user.
+  LeaderboardEntry? getEntryForUser(String userId) {
+    try {
+      return entries.firstWhere((entry) => entry.userId.value == userId);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /// Gets the all-time champion (most total stars).
+  LeaderboardEntry? get allTimeChampion {
+    return entries.isNotEmpty ? entries.first : null;
+  }
+
+  /// Gets the highest all-time stars achieved.
+  int get highestAllTimeStars {
+    if (entries.isEmpty) return 0;
+    return entries.first.allTimeStars;
+  }
+
+  /// Gets the most quests completed by any member.
+  int get mostQuestsCompleted {
+    if (entries.isEmpty) return 0;
+    return entries.map((entry) => entry.questsCompleted).reduce((a, b) => a > b ? a : b);
+  }
+
+  /// Gets the longest streak achieved by any member.
+  int get longestStreakAchieved {
+    if (entries.isEmpty) return 0;
+    return entries.map((entry) => entry.longestStreak).reduce((a, b) => a > b ? a : b);
+  }
+
+  /// Gets the total all-time stars across all members.
+  int get totalAllTimeStars {
+    return entries.fold<int>(0, (sum, entry) => sum + entry.allTimeStars);
+  }
+
+  /// Gets the total quests completed across all members.
+  int get totalQuestsCompleted {
+    return entries.fold<int>(0, (sum, entry) => sum + entry.questsCompleted);
+  }
+}

--- a/lib/presentation/providers/riverpod/alltime_leaderboard_notifier.g.dart
+++ b/lib/presentation/providers/riverpod/alltime_leaderboard_notifier.g.dart
@@ -1,0 +1,212 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'alltime_leaderboard_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$allTimeLeaderboardNotifierHash() =>
+    r'597d66f5f57a3a210652e29127f1e4ac484ca938';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+abstract class _$AllTimeLeaderboardNotifier
+    extends BuildlessAutoDisposeAsyncNotifier<List<LeaderboardEntry>> {
+  late final FamilyId familyId;
+
+  FutureOr<List<LeaderboardEntry>> build(FamilyId familyId);
+}
+
+/// Manages all-time leaderboard data for a family.
+///
+/// This notifier fetches and manages all-time leaderboard entries showing
+/// family member lifetime statistics: total stars, quests completed, longest streak.
+///
+/// Copied from [AllTimeLeaderboardNotifier].
+@ProviderFor(AllTimeLeaderboardNotifier)
+const allTimeLeaderboardNotifierProvider = AllTimeLeaderboardNotifierFamily();
+
+/// Manages all-time leaderboard data for a family.
+///
+/// This notifier fetches and manages all-time leaderboard entries showing
+/// family member lifetime statistics: total stars, quests completed, longest streak.
+///
+/// Copied from [AllTimeLeaderboardNotifier].
+class AllTimeLeaderboardNotifierFamily
+    extends Family<AsyncValue<List<LeaderboardEntry>>> {
+  /// Manages all-time leaderboard data for a family.
+  ///
+  /// This notifier fetches and manages all-time leaderboard entries showing
+  /// family member lifetime statistics: total stars, quests completed, longest streak.
+  ///
+  /// Copied from [AllTimeLeaderboardNotifier].
+  const AllTimeLeaderboardNotifierFamily();
+
+  /// Manages all-time leaderboard data for a family.
+  ///
+  /// This notifier fetches and manages all-time leaderboard entries showing
+  /// family member lifetime statistics: total stars, quests completed, longest streak.
+  ///
+  /// Copied from [AllTimeLeaderboardNotifier].
+  AllTimeLeaderboardNotifierProvider call(FamilyId familyId) {
+    return AllTimeLeaderboardNotifierProvider(familyId);
+  }
+
+  @override
+  AllTimeLeaderboardNotifierProvider getProviderOverride(
+    covariant AllTimeLeaderboardNotifierProvider provider,
+  ) {
+    return call(provider.familyId);
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'allTimeLeaderboardNotifierProvider';
+}
+
+/// Manages all-time leaderboard data for a family.
+///
+/// This notifier fetches and manages all-time leaderboard entries showing
+/// family member lifetime statistics: total stars, quests completed, longest streak.
+///
+/// Copied from [AllTimeLeaderboardNotifier].
+class AllTimeLeaderboardNotifierProvider
+    extends
+        AutoDisposeAsyncNotifierProviderImpl<
+          AllTimeLeaderboardNotifier,
+          List<LeaderboardEntry>
+        > {
+  /// Manages all-time leaderboard data for a family.
+  ///
+  /// This notifier fetches and manages all-time leaderboard entries showing
+  /// family member lifetime statistics: total stars, quests completed, longest streak.
+  ///
+  /// Copied from [AllTimeLeaderboardNotifier].
+  AllTimeLeaderboardNotifierProvider(FamilyId familyId)
+    : this._internal(
+        () => AllTimeLeaderboardNotifier()..familyId = familyId,
+        from: allTimeLeaderboardNotifierProvider,
+        name: r'allTimeLeaderboardNotifierProvider',
+        debugGetCreateSourceHash:
+            const bool.fromEnvironment('dart.vm.product')
+                ? null
+                : _$allTimeLeaderboardNotifierHash,
+        dependencies: AllTimeLeaderboardNotifierFamily._dependencies,
+        allTransitiveDependencies:
+            AllTimeLeaderboardNotifierFamily._allTransitiveDependencies,
+        familyId: familyId,
+      );
+
+  AllTimeLeaderboardNotifierProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.familyId,
+  }) : super.internal();
+
+  final FamilyId familyId;
+
+  @override
+  FutureOr<List<LeaderboardEntry>> runNotifierBuild(
+    covariant AllTimeLeaderboardNotifier notifier,
+  ) {
+    return notifier.build(familyId);
+  }
+
+  @override
+  Override overrideWith(AllTimeLeaderboardNotifier Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: AllTimeLeaderboardNotifierProvider._internal(
+        () => create()..familyId = familyId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        familyId: familyId,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeAsyncNotifierProviderElement<
+    AllTimeLeaderboardNotifier,
+    List<LeaderboardEntry>
+  >
+  createElement() {
+    return _AllTimeLeaderboardNotifierProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is AllTimeLeaderboardNotifierProvider &&
+        other.familyId == familyId;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, familyId.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+mixin AllTimeLeaderboardNotifierRef
+    on AutoDisposeAsyncNotifierProviderRef<List<LeaderboardEntry>> {
+  /// The parameter `familyId` of this provider.
+  FamilyId get familyId;
+}
+
+class _AllTimeLeaderboardNotifierProviderElement
+    extends
+        AutoDisposeAsyncNotifierProviderElement<
+          AllTimeLeaderboardNotifier,
+          List<LeaderboardEntry>
+        >
+    with AllTimeLeaderboardNotifierRef {
+  _AllTimeLeaderboardNotifierProviderElement(super.provider);
+
+  @override
+  FamilyId get familyId =>
+      (origin as AllTimeLeaderboardNotifierProvider).familyId;
+}
+
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/presentation/providers/riverpod/weekly_leaderboard_notifier.dart
+++ b/lib/presentation/providers/riverpod/weekly_leaderboard_notifier.dart
@@ -1,0 +1,223 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:hoque_family_chores/domain/entities/leaderboard_entry.dart';
+import 'package:hoque_family_chores/domain/value_objects/family_id.dart';
+import 'package:hoque_family_chores/utils/logger.dart';
+import 'package:hoque_family_chores/di/riverpod_container.dart';
+import 'dart:async';
+
+part 'weekly_leaderboard_notifier.g.dart';
+
+/// Manages weekly leaderboard data for a family.
+/// 
+/// This notifier fetches and manages weekly leaderboard entries showing
+/// family member rankings based on stars earned this week (Monday-Sunday).
+/// 
+/// Features:
+/// - Weekly star tracking
+/// - Podium for top 3
+/// - Rank change indicators
+/// - Champion badge tracking
+/// - Week countdown timer
+@riverpod
+class WeeklyLeaderboardNotifier extends _$WeeklyLeaderboardNotifier {
+  final _logger = AppLogger();
+  Timer? _weekTimer;
+
+  @override
+  Future<List<LeaderboardEntry>> build(FamilyId familyId) async {
+    _logger.d('WeeklyLeaderboardNotifier: Building for family $familyId');
+    
+    // Start week countdown timer
+    _startWeekCountdownTimer();
+    
+    // Clean up timer when provider is disposed
+    ref.onDispose(() {
+      _weekTimer?.cancel();
+    });
+    
+    try {
+      final getWeeklyLeaderboardUseCase = ref.watch(getWeeklyLeaderboardUseCaseProvider);
+      final result = await getWeeklyLeaderboardUseCase.call(familyId: familyId);
+      
+      return result.fold(
+        (failure) => throw Exception(failure.message),
+        (entries) {
+          _logger.d('WeeklyLeaderboardNotifier: Loaded ${entries.length} entries for weekly leaderboard');
+          return entries;
+        },
+      );
+    } catch (e) {
+      _logger.e('WeeklyLeaderboardNotifier: Error loading weekly leaderboard', error: e);
+      throw Exception('Failed to load weekly leaderboard: $e');
+    }
+  }
+
+  /// Starts a timer to refresh leaderboard when the week resets
+  void _startWeekCountdownTimer() {
+    final weekEnd = getWeekEnd();
+    final now = DateTime.now();
+    final timeUntilReset = weekEnd.difference(now);
+    
+    if (timeUntilReset.isNegative) {
+      // Week already ended, refresh immediately
+      Future.microtask(() => refresh());
+      return;
+    }
+    
+    // Schedule refresh at week end
+    _weekTimer = Timer(timeUntilReset, () {
+      _logger.d('WeeklyLeaderboardNotifier: Week reset, refreshing leaderboard');
+      refresh();
+    });
+  }
+
+  /// Refreshes the weekly leaderboard data.
+  Future<void> refresh() async {
+    _logger.d('WeeklyLeaderboardNotifier: Refreshing weekly leaderboard');
+    ref.invalidateSelf();
+  }
+
+  /// Gets the current list of leaderboard entries.
+  List<LeaderboardEntry> get entries => state.value ?? [];
+
+  /// Gets the current loading state.
+  bool get isLoading => state.isLoading;
+
+  /// Gets the current error message.
+  String? get errorMessage => state.hasError ? state.error.toString() : null;
+
+  /// Gets the current state status.
+  LeaderboardState get status {
+    if (state.isLoading) return LeaderboardState.loading;
+    if (state.hasError) return LeaderboardState.error;
+    return LeaderboardState.loaded;
+  }
+
+  /// Gets the top 3 entries for the podium.
+  List<LeaderboardEntry> get podium {
+    return entries.take(3).toList();
+  }
+
+  /// Gets entries beyond the podium (rank 4+).
+  List<LeaderboardEntry> get remainingEntries {
+    return entries.length > 3 ? entries.skip(3).toList() : [];
+  }
+
+  /// Gets the current week's champion (rank #1).
+  LeaderboardEntry? get champion {
+    return entries.isNotEmpty ? entries.first : null;
+  }
+
+  /// Gets entries for a specific user.
+  LeaderboardEntry? getEntryForUser(String userId) {
+    try {
+      return entries.firstWhere((entry) => entry.userId.value == userId);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /// Gets the rank of a specific user.
+  int? getRankForUser(String userId) {
+    final entry = getEntryForUser(userId);
+    return entry?.rank;
+  }
+
+  /// Gets the current week start date (Monday at 00:00).
+  DateTime getWeekStart() {
+    final useCase = ref.read(getWeeklyLeaderboardUseCaseProvider);
+    return useCase.getWeekStart();
+  }
+
+  /// Gets the current week end date (Sunday at 23:59).
+  DateTime getWeekEnd() {
+    final useCase = ref.read(getWeeklyLeaderboardUseCaseProvider);
+    return useCase.getWeekEnd();
+  }
+
+  /// Gets time remaining until week reset.
+  Duration getTimeUntilReset() {
+    final weekEnd = getWeekEnd();
+    final now = DateTime.now();
+    return weekEnd.difference(now);
+  }
+
+  /// Gets formatted time until reset (e.g., "2d 14h 23m").
+  String getFormattedTimeUntilReset() {
+    final duration = getTimeUntilReset();
+    
+    if (duration.isNegative) return '0d 0h 0m';
+    
+    final days = duration.inDays;
+    final hours = duration.inHours.remainder(24);
+    final minutes = duration.inMinutes.remainder(60);
+    
+    return '${days}d ${hours}h ${minutes}m';
+  }
+
+  /// Gets week progress percentage (0.0 to 1.0).
+  double getWeekProgress() {
+    final weekStart = getWeekStart();
+    final weekEnd = getWeekEnd();
+    final now = DateTime.now();
+    
+    final totalDuration = weekEnd.difference(weekStart).inMilliseconds;
+    final elapsedDuration = now.difference(weekStart).inMilliseconds;
+    
+    if (totalDuration <= 0) return 0.0;
+    
+    final progress = elapsedDuration / totalDuration;
+    return progress.clamp(0.0, 1.0);
+  }
+
+  /// Gets the average weekly stars across all members.
+  double get averageWeeklyStars {
+    if (entries.isEmpty) return 0.0;
+    final totalStars = entries.fold<int>(0, (sum, entry) => sum + entry.weeklyStars);
+    return totalStars / entries.length;
+  }
+
+  /// Gets the total weekly stars across all members.
+  int get totalWeeklyStars {
+    return entries.fold<int>(0, (sum, entry) => sum + entry.weeklyStars);
+  }
+
+  /// Gets entries with rank improvements from last week.
+  List<LeaderboardEntry> get improvedRanks {
+    return entries.where((entry) => entry.rankChange == RankChange.up).toList();
+  }
+
+  /// Gets entries with rank declines from last week.
+  List<LeaderboardEntry> get declinedRanks {
+    return entries.where((entry) => entry.rankChange == RankChange.down).toList();
+  }
+
+  /// Checks if a user has the champion badge.
+  bool isChampion(String userId) {
+    final entry = getEntryForUser(userId);
+    return entry?.hasChampionBadge ?? false;
+  }
+
+  /// Gets the week date range as a formatted string (e.g., "Jan 6 - Jan 12").
+  String getWeekDateRange() {
+    final weekStart = getWeekStart();
+    final weekEnd = getWeekEnd();
+    
+    final monthNames = [
+      '', 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+    ];
+    
+    final startMonth = monthNames[weekStart.month];
+    final endMonth = monthNames[weekEnd.month];
+    
+    if (weekStart.month == weekEnd.month) {
+      return '$startMonth ${weekStart.day} - ${weekEnd.day}';
+    } else {
+      return '$startMonth ${weekStart.day} - $endMonth ${weekEnd.day}';
+    }
+  }
+}
+
+/// Enum for leaderboard state.
+enum LeaderboardState { initial, loading, loaded, error }

--- a/lib/presentation/providers/riverpod/weekly_leaderboard_notifier.g.dart
+++ b/lib/presentation/providers/riverpod/weekly_leaderboard_notifier.g.dart
@@ -1,0 +1,254 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'weekly_leaderboard_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$weeklyLeaderboardNotifierHash() =>
+    r'10e33292406b40c9ec27b161f49b184535fe0356';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+abstract class _$WeeklyLeaderboardNotifier
+    extends BuildlessAutoDisposeAsyncNotifier<List<LeaderboardEntry>> {
+  late final FamilyId familyId;
+
+  FutureOr<List<LeaderboardEntry>> build(FamilyId familyId);
+}
+
+/// Manages weekly leaderboard data for a family.
+///
+/// This notifier fetches and manages weekly leaderboard entries showing
+/// family member rankings based on stars earned this week (Monday-Sunday).
+///
+/// Features:
+/// - Weekly star tracking
+/// - Podium for top 3
+/// - Rank change indicators
+/// - Champion badge tracking
+/// - Week countdown timer
+///
+/// Copied from [WeeklyLeaderboardNotifier].
+@ProviderFor(WeeklyLeaderboardNotifier)
+const weeklyLeaderboardNotifierProvider = WeeklyLeaderboardNotifierFamily();
+
+/// Manages weekly leaderboard data for a family.
+///
+/// This notifier fetches and manages weekly leaderboard entries showing
+/// family member rankings based on stars earned this week (Monday-Sunday).
+///
+/// Features:
+/// - Weekly star tracking
+/// - Podium for top 3
+/// - Rank change indicators
+/// - Champion badge tracking
+/// - Week countdown timer
+///
+/// Copied from [WeeklyLeaderboardNotifier].
+class WeeklyLeaderboardNotifierFamily
+    extends Family<AsyncValue<List<LeaderboardEntry>>> {
+  /// Manages weekly leaderboard data for a family.
+  ///
+  /// This notifier fetches and manages weekly leaderboard entries showing
+  /// family member rankings based on stars earned this week (Monday-Sunday).
+  ///
+  /// Features:
+  /// - Weekly star tracking
+  /// - Podium for top 3
+  /// - Rank change indicators
+  /// - Champion badge tracking
+  /// - Week countdown timer
+  ///
+  /// Copied from [WeeklyLeaderboardNotifier].
+  const WeeklyLeaderboardNotifierFamily();
+
+  /// Manages weekly leaderboard data for a family.
+  ///
+  /// This notifier fetches and manages weekly leaderboard entries showing
+  /// family member rankings based on stars earned this week (Monday-Sunday).
+  ///
+  /// Features:
+  /// - Weekly star tracking
+  /// - Podium for top 3
+  /// - Rank change indicators
+  /// - Champion badge tracking
+  /// - Week countdown timer
+  ///
+  /// Copied from [WeeklyLeaderboardNotifier].
+  WeeklyLeaderboardNotifierProvider call(FamilyId familyId) {
+    return WeeklyLeaderboardNotifierProvider(familyId);
+  }
+
+  @override
+  WeeklyLeaderboardNotifierProvider getProviderOverride(
+    covariant WeeklyLeaderboardNotifierProvider provider,
+  ) {
+    return call(provider.familyId);
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'weeklyLeaderboardNotifierProvider';
+}
+
+/// Manages weekly leaderboard data for a family.
+///
+/// This notifier fetches and manages weekly leaderboard entries showing
+/// family member rankings based on stars earned this week (Monday-Sunday).
+///
+/// Features:
+/// - Weekly star tracking
+/// - Podium for top 3
+/// - Rank change indicators
+/// - Champion badge tracking
+/// - Week countdown timer
+///
+/// Copied from [WeeklyLeaderboardNotifier].
+class WeeklyLeaderboardNotifierProvider
+    extends
+        AutoDisposeAsyncNotifierProviderImpl<
+          WeeklyLeaderboardNotifier,
+          List<LeaderboardEntry>
+        > {
+  /// Manages weekly leaderboard data for a family.
+  ///
+  /// This notifier fetches and manages weekly leaderboard entries showing
+  /// family member rankings based on stars earned this week (Monday-Sunday).
+  ///
+  /// Features:
+  /// - Weekly star tracking
+  /// - Podium for top 3
+  /// - Rank change indicators
+  /// - Champion badge tracking
+  /// - Week countdown timer
+  ///
+  /// Copied from [WeeklyLeaderboardNotifier].
+  WeeklyLeaderboardNotifierProvider(FamilyId familyId)
+    : this._internal(
+        () => WeeklyLeaderboardNotifier()..familyId = familyId,
+        from: weeklyLeaderboardNotifierProvider,
+        name: r'weeklyLeaderboardNotifierProvider',
+        debugGetCreateSourceHash:
+            const bool.fromEnvironment('dart.vm.product')
+                ? null
+                : _$weeklyLeaderboardNotifierHash,
+        dependencies: WeeklyLeaderboardNotifierFamily._dependencies,
+        allTransitiveDependencies:
+            WeeklyLeaderboardNotifierFamily._allTransitiveDependencies,
+        familyId: familyId,
+      );
+
+  WeeklyLeaderboardNotifierProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.familyId,
+  }) : super.internal();
+
+  final FamilyId familyId;
+
+  @override
+  FutureOr<List<LeaderboardEntry>> runNotifierBuild(
+    covariant WeeklyLeaderboardNotifier notifier,
+  ) {
+    return notifier.build(familyId);
+  }
+
+  @override
+  Override overrideWith(WeeklyLeaderboardNotifier Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: WeeklyLeaderboardNotifierProvider._internal(
+        () => create()..familyId = familyId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        familyId: familyId,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeAsyncNotifierProviderElement<
+    WeeklyLeaderboardNotifier,
+    List<LeaderboardEntry>
+  >
+  createElement() {
+    return _WeeklyLeaderboardNotifierProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is WeeklyLeaderboardNotifierProvider &&
+        other.familyId == familyId;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, familyId.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+mixin WeeklyLeaderboardNotifierRef
+    on AutoDisposeAsyncNotifierProviderRef<List<LeaderboardEntry>> {
+  /// The parameter `familyId` of this provider.
+  FamilyId get familyId;
+}
+
+class _WeeklyLeaderboardNotifierProviderElement
+    extends
+        AutoDisposeAsyncNotifierProviderElement<
+          WeeklyLeaderboardNotifier,
+          List<LeaderboardEntry>
+        >
+    with WeeklyLeaderboardNotifierRef {
+  _WeeklyLeaderboardNotifierProviderElement(super.provider);
+
+  @override
+  FamilyId get familyId =>
+      (origin as WeeklyLeaderboardNotifierProvider).familyId;
+}
+
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/presentation/screens/leaderboard_screen.dart
+++ b/lib/presentation/screens/leaderboard_screen.dart
@@ -1,0 +1,289 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../domain/entities/leaderboard_entry.dart';
+import '../../domain/value_objects/family_id.dart';
+import '../providers/riverpod/weekly_leaderboard_notifier.dart';
+import '../providers/riverpod/alltime_leaderboard_notifier.dart';
+import '../widgets/leaderboard/podium_widget.dart';
+import '../widgets/leaderboard/weekly_countdown_widget.dart';
+import '../widgets/leaderboard/leaderboard_list_widget.dart';
+import '../widgets/leaderboard/alltime_stats_widget.dart';
+
+/// Main leaderboard screen with weekly and all-time tabs
+class LeaderboardScreen extends ConsumerStatefulWidget {
+  final FamilyId familyId;
+  final String? currentUserId;
+
+  const LeaderboardScreen({
+    super.key,
+    required this.familyId,
+    this.currentUserId,
+  });
+
+  @override
+  ConsumerState<LeaderboardScreen> createState() => _LeaderboardScreenState();
+}
+
+class _LeaderboardScreenState extends ConsumerState<LeaderboardScreen>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Family Leaderboard'),
+        centerTitle: true,
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: const [
+            Tab(text: 'This Week'),
+            Tab(text: 'All Time'),
+          ],
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          _buildWeeklyTab(),
+          _buildAllTimeTab(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildWeeklyTab() {
+    final weeklyLeaderboardAsync = ref.watch(
+      weeklyLeaderboardNotifierProvider(widget.familyId),
+    );
+
+    return weeklyLeaderboardAsync.when(
+      data: (entries) {
+        if (entries.isEmpty) {
+          return _buildEmptyState();
+        }
+
+        // Split into podium (top 3) and rest
+        final podiumEntries = entries.take(3).toList();
+        final remainingEntries = entries.length > 3 
+            ? List<LeaderboardEntry>.from(entries.skip(3)) 
+            : <LeaderboardEntry>[];
+
+        final notifier = ref.read(
+          weeklyLeaderboardNotifierProvider(widget.familyId).notifier,
+        );
+
+        return RefreshIndicator(
+          onRefresh: () async {
+            await notifier.refresh();
+          },
+          child: SingleChildScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            child: Column(
+              children: [
+                const SizedBox(height: 16),
+                
+                // Week date range header
+                Text(
+                  'Week of ${notifier.getWeekDateRange()}',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        color: Colors.grey[600],
+                      ),
+                ),
+                
+                const SizedBox(height: 24),
+                
+                // Podium for top 3
+                if (podiumEntries.isNotEmpty)
+                  PodiumWidget(
+                    entries: podiumEntries,
+                    currentUserId: widget.currentUserId,
+                  ),
+                
+                const SizedBox(height: 24),
+                
+                // Weekly countdown timer
+                WeeklyCountdownWidget(
+                  weekStart: notifier.getWeekStart(),
+                  weekEnd: notifier.getWeekEnd(),
+                ),
+                
+                const SizedBox(height: 24),
+                
+                // Remaining entries (4th place and below)
+                if (remainingEntries.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: LeaderboardListWidget(
+                      entries: remainingEntries,
+                      currentUserId: widget.currentUserId,
+                      showWeeklyStats: true,
+                    ),
+                  ),
+                
+                const SizedBox(height: 16),
+              ],
+            ),
+          ),
+        );
+      },
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (error, stack) => Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.error_outline, size: 48, color: Colors.red),
+            const SizedBox(height: 16),
+            Text('Error loading leaderboard'),
+            const SizedBox(height: 8),
+            Text(
+              error.toString(),
+              style: Theme.of(context).textTheme.bodySmall,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                ref.invalidate(weeklyLeaderboardNotifierProvider(widget.familyId));
+              },
+              child: const Text('Retry'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAllTimeTab() {
+    final allTimeLeaderboardAsync = ref.watch(
+      allTimeLeaderboardNotifierProvider(widget.familyId),
+    );
+
+    return allTimeLeaderboardAsync.when(
+      data: (entries) {
+        if (entries.isEmpty) {
+          return _buildEmptyState();
+        }
+
+        final notifier = ref.read(
+          allTimeLeaderboardNotifierProvider(widget.familyId).notifier,
+        );
+
+        return RefreshIndicator(
+          onRefresh: () async {
+            await notifier.refresh();
+          },
+          child: SingleChildScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            child: Column(
+              children: [
+                const SizedBox(height: 16),
+                
+                // All-time statistics
+                AllTimeStatsWidget(
+                  entries: entries,
+                  currentUserId: widget.currentUserId,
+                ),
+                
+                const SizedBox(height: 16),
+              ],
+            ),
+          ),
+        );
+      },
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (error, stack) => Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.error_outline, size: 48, color: Colors.red),
+            const SizedBox(height: 16),
+            Text('Error loading all-time leaderboard'),
+            const SizedBox(height: 8),
+            Text(
+              error.toString(),
+              style: Theme.of(context).textTheme.bodySmall,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                ref.invalidate(allTimeLeaderboardNotifierProvider(widget.familyId));
+              },
+              child: const Text('Retry'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEmptyState() {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(
+              Icons.emoji_events,
+              size: 80,
+              color: Colors.grey,
+            ),
+            const SizedBox(height: 24),
+            const Text(
+              'Let the games begin!',
+              style: TextStyle(
+                fontSize: 24,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Complete chores to earn your spot\non the family leaderboard',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 16,
+                color: Colors.grey[600],
+              ),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton.icon(
+              onPressed: () {
+                Navigator.pop(context);
+              },
+              icon: const Icon(Icons.task_alt),
+              label: const Text('Start First Quest'),
+              style: ElevatedButton.styleFrom(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 24,
+                  vertical: 12,
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Winner announced every Sunday!',
+              style: TextStyle(
+                fontSize: 14,
+                color: Colors.grey[500],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/leaderboard/alltime_stats_widget.dart
+++ b/lib/presentation/widgets/leaderboard/alltime_stats_widget.dart
@@ -1,0 +1,358 @@
+import 'package:flutter/material.dart';
+import '../../../domain/entities/leaderboard_entry.dart';
+
+/// Widget displaying all-time statistics leaderboard
+class AllTimeStatsWidget extends StatelessWidget {
+  final List<LeaderboardEntry> entries;
+  final String? currentUserId;
+
+  const AllTimeStatsWidget({
+    super.key,
+    required this.entries,
+    this.currentUserId,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (entries.isEmpty) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(32.0),
+          child: Text('No statistics available yet.'),
+        ),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Header
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Text(
+            '🏆 ALL-TIME CHAMPIONS',
+            style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+          ),
+        ),
+        
+        const SizedBox(height: 8),
+        
+        // Records section
+        _buildRecordsSection(context),
+        
+        const SizedBox(height: 24),
+        
+        // All-time leaderboard
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Column(
+            children: entries.map((entry) => _buildStatCard(context, entry)).toList(),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildRecordsSection(BuildContext context) {
+    if (entries.isEmpty) return const SizedBox.shrink();
+    
+    // Calculate records
+    final highestAllTimeStars = entries.first.allTimeStars;
+    final longestStreak = entries.map((e) => e.longestStreak).reduce((a, b) => a > b ? a : b);
+    final mostQuests = entries.map((e) => e.questsCompleted).reduce((a, b) => a > b ? a : b);
+    
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [
+            Theme.of(context).primaryColor.withOpacity(0.1),
+            Theme.of(context).primaryColor.withOpacity(0.05),
+          ],
+        ),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '🏅 FAMILY RECORDS',
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+          ),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              Expanded(
+                child: _buildRecordTile(
+                  context,
+                  icon: '⭐',
+                  value: highestAllTimeStars.toString(),
+                  label: 'Highest Stars',
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: _buildRecordTile(
+                  context,
+                  icon: '🔥',
+                  value: '$longestStreak days',
+                  label: 'Longest Streak',
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: _buildRecordTile(
+                  context,
+                  icon: '✅',
+                  value: mostQuests.toString(),
+                  label: 'Most Quests',
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Container(), // Placeholder for symmetry
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRecordTile(
+    BuildContext context, {
+    required String icon,
+    required String value,
+    required String label,
+  }) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(icon, style: const TextStyle(fontSize: 20)),
+          const SizedBox(height: 4),
+          Text(
+            value,
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            label,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Colors.grey[600],
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStatCard(BuildContext context, LeaderboardEntry entry) {
+    final isCurrentUser = currentUserId != null && entry.userId.value == currentUserId;
+    
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: isCurrentUser
+            ? Theme.of(context).primaryColor.withOpacity(0.1)
+            : Theme.of(context).cardColor,
+        borderRadius: BorderRadius.circular(12),
+        border: isCurrentUser
+            ? Border.all(
+                color: Theme.of(context).primaryColor,
+                width: 2,
+              )
+            : null,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 4,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Header row with rank, avatar, name
+          Row(
+            children: [
+              // Rank
+              Container(
+                width: 32,
+                height: 32,
+                decoration: BoxDecoration(
+                  color: entry.rank <= 3
+                      ? _getRankColor(entry.rank)
+                      : Colors.grey[300],
+                  shape: BoxShape.circle,
+                ),
+                child: Center(
+                  child: Text(
+                    entry.rank.toString(),
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ),
+              
+              const SizedBox(width: 12),
+              
+              // Avatar
+              CircleAvatar(
+                radius: 24,
+                backgroundImage: entry.userPhotoUrl != null
+                    ? NetworkImage(entry.userPhotoUrl!)
+                    : null,
+                child: entry.userPhotoUrl == null
+                    ? Text(
+                        entry.userName.substring(0, 1).toUpperCase(),
+                        style: const TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      )
+                    : null,
+              ),
+              
+              const SizedBox(width: 12),
+              
+              // Name and champion badge
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      entry.userName,
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                    ),
+                    if (entry.hasChampionBadge)
+                      const Text(
+                        '🏆 Last Week\'s Champion',
+                        style: TextStyle(fontSize: 12),
+                      ),
+                  ],
+                ),
+              ),
+              
+              // Total stars
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const Text('⭐', style: TextStyle(fontSize: 16)),
+                      const SizedBox(width: 4),
+                      Text(
+                        entry.allTimeStars.toString(),
+                        style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                              fontWeight: FontWeight.bold,
+                              color: Theme.of(context).primaryColor,
+                            ),
+                      ),
+                    ],
+                  ),
+                  Text(
+                    'total',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Colors.grey[600],
+                        ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          
+          const Divider(height: 24),
+          
+          // Stats row
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: [
+              _buildStatColumn(
+                context,
+                icon: '✅',
+                value: entry.questsCompleted.toString(),
+                label: 'Quests',
+              ),
+              _buildStatColumn(
+                context,
+                icon: '🔥',
+                value: entry.longestStreak.toString(),
+                label: 'Best Streak',
+              ),
+              _buildStatColumn(
+                context,
+                icon: '⚡',
+                value: entry.currentStreak.toString(),
+                label: 'Current',
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStatColumn(
+    BuildContext context, {
+    required String icon,
+    required String value,
+    required String label,
+  }) {
+    return Column(
+      children: [
+        Text(icon, style: const TextStyle(fontSize: 20)),
+        const SizedBox(height: 4),
+        Text(
+          value,
+          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          label,
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Colors.grey[600],
+              ),
+        ),
+      ],
+    );
+  }
+
+  Color _getRankColor(int rank) {
+    switch (rank) {
+      case 1:
+        return const Color(0xFFFFD700); // Gold
+      case 2:
+        return const Color(0xFFC0C0C0); // Silver
+      case 3:
+        return const Color(0xFFCD7F32); // Bronze
+      default:
+        return Colors.grey;
+    }
+  }
+}

--- a/lib/presentation/widgets/leaderboard/leaderboard_list_widget.dart
+++ b/lib/presentation/widgets/leaderboard/leaderboard_list_widget.dart
@@ -1,0 +1,192 @@
+import 'package:flutter/material.dart';
+import '../../../domain/entities/leaderboard_entry.dart';
+
+/// Widget displaying leaderboard entries as a list (for ranks 4+)
+class LeaderboardListWidget extends StatelessWidget {
+  final List<LeaderboardEntry> entries;
+  final String? currentUserId;
+  final bool showWeeklyStats;
+
+  const LeaderboardListWidget({
+    super.key,
+    required this.entries,
+    this.currentUserId,
+    this.showWeeklyStats = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (entries.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (showWeeklyStats)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: Text(
+              'Rest of the Pack',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: Colors.grey[700],
+                  ),
+            ),
+          ),
+        ...entries.map((entry) => _buildListItem(context, entry)),
+      ],
+    );
+  }
+
+  Widget _buildListItem(BuildContext context, LeaderboardEntry entry) {
+    final isCurrentUser = currentUserId != null && entry.userId.value == currentUserId;
+    final rankChange = entry.rankChange;
+    
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      decoration: BoxDecoration(
+        color: isCurrentUser
+            ? Theme.of(context).primaryColor.withOpacity(0.1)
+            : Theme.of(context).cardColor,
+        borderRadius: BorderRadius.circular(12),
+        border: isCurrentUser
+            ? Border.all(
+                color: Theme.of(context).primaryColor,
+                width: 2,
+              )
+            : null,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 4,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: ListTile(
+        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        leading: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Rank number
+            SizedBox(
+              width: 32,
+              child: Text(
+                entry.rank.toString(),
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                      color: Colors.grey[600],
+                    ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+            
+            const SizedBox(width: 12),
+            
+            // Avatar
+            CircleAvatar(
+              radius: 24,
+              backgroundImage: entry.userPhotoUrl != null
+                  ? NetworkImage(entry.userPhotoUrl!)
+                  : null,
+              child: entry.userPhotoUrl == null
+                  ? Text(
+                      entry.userName.substring(0, 1).toUpperCase(),
+                      style: const TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    )
+                  : null,
+            ),
+          ],
+        ),
+        title: Row(
+          children: [
+            Expanded(
+              child: Text(
+                entry.userName,
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+              ),
+            ),
+            if (entry.hasChampionBadge)
+              const Padding(
+                padding: EdgeInsets.only(left: 8),
+                child: Text('🏆', style: TextStyle(fontSize: 16)),
+              ),
+          ],
+        ),
+        subtitle: Row(
+          children: [
+            // Streak indicator
+            const Text('🔥', style: TextStyle(fontSize: 12)),
+            const SizedBox(width: 4),
+            Text(
+              '${entry.currentStreak} day streak',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            
+            // Rank change indicator
+            if (rankChange != RankChange.none) ...[
+              const SizedBox(width: 12),
+              _buildRankChangeIndicator(context, rankChange),
+            ],
+          ],
+        ),
+        trailing: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Text('⭐', style: TextStyle(fontSize: 16)),
+                const SizedBox(width: 4),
+                Text(
+                  showWeeklyStats
+                      ? entry.weeklyStars.toString()
+                      : entry.allTimeStars.toString(),
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: Theme.of(context).primaryColor,
+                      ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRankChangeIndicator(BuildContext context, RankChange rankChange) {
+    IconData icon;
+    Color color;
+    
+    switch (rankChange) {
+      case RankChange.up:
+        icon = Icons.arrow_upward;
+        color = Colors.green;
+        break;
+      case RankChange.down:
+        icon = Icons.arrow_downward;
+        color = Colors.grey;
+        break;
+      case RankChange.same:
+        icon = Icons.remove;
+        color = Colors.grey;
+        break;
+      case RankChange.none:
+        return const SizedBox.shrink();
+    }
+    
+    return Icon(
+      icon,
+      size: 16,
+      color: color,
+    );
+  }
+}

--- a/lib/presentation/widgets/leaderboard/podium_widget.dart
+++ b/lib/presentation/widgets/leaderboard/podium_widget.dart
@@ -1,0 +1,230 @@
+import 'package:flutter/material.dart';
+import '../../../domain/entities/leaderboard_entry.dart';
+
+/// Podium widget displaying top 3 leaderboard positions
+/// with gold, silver, and bronze styling
+class PodiumWidget extends StatelessWidget {
+  final List<LeaderboardEntry> entries;
+  final String? currentUserId;
+
+  const PodiumWidget({
+    super.key,
+    required this.entries,
+    this.currentUserId,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // Handle edge cases
+    if (entries.isEmpty) return const SizedBox.shrink();
+    
+    final first = entries.length > 0 ? entries[0] : null;
+    final second = entries.length > 1 ? entries[1] : null;
+    final third = entries.length > 2 ? entries[2] : null;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          // Second place (left)
+          if (second != null)
+            Expanded(
+              child: _buildPodiumPosition(
+                context,
+                entry: second,
+                position: 2,
+                height: 96,
+                color: const Color(0xFFC0C0C0), // Silver
+                badge: '🥈',
+              ),
+            ),
+          
+          const SizedBox(width: 12),
+          
+          // First place (center)
+          if (first != null)
+            Expanded(
+              child: _buildPodiumPosition(
+                context,
+                entry: first,
+                position: 1,
+                height: 120,
+                color: const Color(0xFFFFD700), // Gold
+                badge: '👑',
+              ),
+            ),
+          
+          const SizedBox(width: 12),
+          
+          // Third place (right)
+          if (third != null)
+            Expanded(
+              child: _buildPodiumPosition(
+                context,
+                entry: third,
+                position: 3,
+                height: 72,
+                color: const Color(0xFFCD7F32), // Bronze
+                badge: '🥉',
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPodiumPosition(
+    BuildContext context, {
+    required LeaderboardEntry entry,
+    required int position,
+    required double height,
+    required Color color,
+    required String badge,
+  }) {
+    final isCurrentUser = currentUserId != null && entry.userId.value == currentUserId;
+    
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // Badge (crown/medal)
+        Text(
+          badge,
+          style: const TextStyle(fontSize: 32),
+        ),
+        
+        const SizedBox(height: 8),
+        
+        // Avatar with ring
+        Container(
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            border: Border.all(
+              color: color,
+              width: position == 1 ? 4 : 3,
+            ),
+          ),
+          child: CircleAvatar(
+            radius: position == 1 ? 32 : 28,
+            backgroundImage: entry.userPhotoUrl != null
+                ? NetworkImage(entry.userPhotoUrl!)
+                : null,
+            child: entry.userPhotoUrl == null
+                ? Text(
+                    entry.userName.substring(0, 1).toUpperCase(),
+                    style: TextStyle(
+                      fontSize: position == 1 ? 24 : 20,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  )
+                : null,
+          ),
+        ),
+        
+        const SizedBox(height: 8),
+        
+        // Name
+        Text(
+          entry.userName,
+          style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                fontWeight: position == 1 ? FontWeight.bold : FontWeight.w600,
+                color: isCurrentUser ? Theme.of(context).primaryColor : null,
+              ),
+          textAlign: TextAlign.center,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        
+        const SizedBox(height: 4),
+        
+        // Weekly stars
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text('⭐', style: TextStyle(fontSize: 14)),
+            const SizedBox(width: 4),
+            Text(
+              entry.weeklyStars.toString(),
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: color,
+                  ),
+            ),
+          ],
+        ),
+        
+        const SizedBox(height: 4),
+        
+        // Current streak
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text('🔥', style: TextStyle(fontSize: 12)),
+            const SizedBox(width: 4),
+            Text(
+              entry.currentStreak.toString(),
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ],
+        ),
+        
+        const SizedBox(height: 8),
+        
+        // Podium base
+        Container(
+          height: height,
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [
+                color,
+                color.withOpacity(0.7),
+              ],
+            ),
+            borderRadius: const BorderRadius.vertical(
+              top: Radius.circular(8),
+            ),
+          ),
+          child: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  _getPositionText(position),
+                  style: const TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                  ),
+                ),
+                if (entry.hasChampionBadge)
+                  const Padding(
+                    padding: EdgeInsets.only(top: 4),
+                    child: Text(
+                      '🏆',
+                      style: TextStyle(fontSize: 16),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  String _getPositionText(int position) {
+    switch (position) {
+      case 1:
+        return '1ST';
+      case 2:
+        return '2ND';
+      case 3:
+        return '3RD';
+      default:
+        return '${position}TH';
+    }
+  }
+}

--- a/lib/presentation/widgets/leaderboard/weekly_countdown_widget.dart
+++ b/lib/presentation/widgets/leaderboard/weekly_countdown_widget.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+import 'dart:async';
+
+/// Widget displaying weekly countdown timer and progress bar
+class WeeklyCountdownWidget extends StatefulWidget {
+  final DateTime weekStart;
+  final DateTime weekEnd;
+
+  const WeeklyCountdownWidget({
+    super.key,
+    required this.weekStart,
+    required this.weekEnd,
+  });
+
+  @override
+  State<WeeklyCountdownWidget> createState() => _WeeklyCountdownWidgetState();
+}
+
+class _WeeklyCountdownWidgetState extends State<WeeklyCountdownWidget> {
+  late Timer _timer;
+  Duration _timeRemaining = Duration.zero;
+  double _progress = 0.0;
+
+  @override
+  void initState() {
+    super.initState();
+    _updateTime();
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) => _updateTime());
+  }
+
+  @override
+  void dispose() {
+    _timer.cancel();
+    super.dispose();
+  }
+
+  void _updateTime() {
+    if (!mounted) return;
+    
+    setState(() {
+      final now = DateTime.now();
+      _timeRemaining = widget.weekEnd.difference(now);
+      
+      if (_timeRemaining.isNegative) {
+        _timeRemaining = Duration.zero;
+        _progress = 1.0;
+      } else {
+        final totalDuration = widget.weekEnd.difference(widget.weekStart).inMilliseconds;
+        final elapsed = now.difference(widget.weekStart).inMilliseconds;
+        _progress = totalDuration > 0 ? (elapsed / totalDuration).clamp(0.0, 1.0) : 0.0;
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Theme.of(context).cardColor,
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Timer header
+          Row(
+            children: [
+              const Icon(Icons.timer_outlined, size: 20),
+              const SizedBox(width: 8),
+              Text(
+                'Week resets in',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+            ],
+          ),
+          
+          const SizedBox(height: 16),
+          
+          // Countdown numbers
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              _buildTimeUnit(
+                context,
+                value: _timeRemaining.inDays,
+                label: 'days',
+              ),
+              const SizedBox(width: 16),
+              _buildTimeUnit(
+                context,
+                value: _timeRemaining.inHours.remainder(24),
+                label: 'hours',
+              ),
+              const SizedBox(width: 16),
+              _buildTimeUnit(
+                context,
+                value: _timeRemaining.inMinutes.remainder(60),
+                label: 'mins',
+              ),
+            ],
+          ),
+          
+          const SizedBox(height: 16),
+          
+          // Progress bar
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              ClipRRect(
+                borderRadius: BorderRadius.circular(4),
+                child: LinearProgressIndicator(
+                  value: _progress,
+                  minHeight: 8,
+                  backgroundColor: Colors.grey[200],
+                  valueColor: AlwaysStoppedAnimation<Color>(
+                    Theme.of(context).primaryColor,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Week ${(_progress * 100).toInt()}% done',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Colors.grey[600],
+                    ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTimeUnit(BuildContext context, {required int value, required String label}) {
+    return Column(
+      children: [
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          decoration: BoxDecoration(
+            color: Theme.of(context).primaryColor.withOpacity(0.1),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Text(
+            value.toString().padLeft(2, '0'),
+            style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: Theme.of(context).primaryColor,
+                ),
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          label,
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Colors.grey[600],
+              ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Weekly family leaderboard with podium, countdown timer, rank tracking, and all-time stats.

## Features
- **Podium widget** for top 3 (gold/silver/bronze with crown 👑 and medals)
- **Weekly countdown** timer to Monday reset
- **Rank change indicators** (↑↓↔)
- **All-time stats** tab with family records
- **Champion badge** for weekly winners
- **Tiebreaker logic** (stars → quests → streak → alphabetical)

## Testing
- ✅ 112 tests passing, 0 analysis errors

Closes #113 | Part of Epic #106